### PR TITLE
router: add Yahoo and Apple news feeds; fix WSDOT router; add TTL for metadata list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ Current route families include:
 - `/zaobao/realtime/<region>`
 - `/apnews/top`
 - `/apnews/business`
+- `/yahoo/reuters/<topic>`
 
 ### Parameterized Routes
 
 - Reuters supports categories such as `world` and `business`, with optional topic and limit parameters.
 - Zaobao supports a general realtime feed plus region-specific feeds such as `china` and `world`.
+- Yahoo News (Reuters) supports topics such as `world`, `business`, `celebrity`, `politics`, `health`, `news`, and `u.s.`.
 
 ## Configuration
 
@@ -90,6 +92,7 @@ router_refresh_periods:
   zaobao: 10
   apnews_top: 15
   apnews_business: 15
+  yahoo_news: 5
 ```
 
 If a key is missing, the router falls back to its hardcoded default.

--- a/app.py
+++ b/app.py
@@ -29,12 +29,14 @@ from router.reuters.reuters_constants import is_valid_reuters_parameter
 from router.zaobao.zaobao_realtime_router_constants import zaobao_region_parameter, title_filter
 from router_objects import meta_tech_blog, cnbeta, usgs_earthquake_report, \
     zaobao_realtime, day_one_blog, wsdot_news, chinese_embassy_news, \
-    jandan_news, reuters_news, sony_alpha_rumors, apnews_top_news, apnews_business
+    jandan_news, reuters_news, sony_alpha_rumors, apnews_top_news, apnews_business, yahoo_news, \
+    apple_developer_news, apple_newsroom
 from utils.router_constants import wsdot_news_router_path, \
     meta_engineering_blog_router, \
     jandan_router_path, earthquake_router_path, embassy_router_path, \
     day_one_blog_router_path, cnbeta_router_path, zaobao_router_path_prefix, \
-    reuters_news_router_path, sar_router_path, apnews_router_path, apnews_business_router_path
+    reuters_news_router_path, sar_router_path, apnews_router_path, apnews_business_router_path, \
+    yahoo_news_router_path_prefix, apple_news_router_path, apple_newsroom_router_path
 from utils.scheduler import router_refresh_job_scheduler
 from werkzeug.exceptions import abort
 
@@ -129,6 +131,21 @@ def build_scheduler_jobs():
             "name": apnews_business_router_path,
             "warmup": lambda: apnews_business.warm_cache(),
             "refresh": lambda: apnews_business.refresh_cache(),
+        },
+        {
+            "name": yahoo_news_router_path_prefix,
+            "warmup": lambda: yahoo_news.refresh_all_topics(),
+            "refresh": lambda: yahoo_news.refresh_all_topics(),
+        },
+        {
+            "name": apple_news_router_path,
+            "warmup": lambda: apple_developer_news.warm_cache(),
+            "refresh": lambda: apple_developer_news.refresh_cache(),
+        },
+        {
+            "name": apple_newsroom_router_path,
+            "warmup": lambda: apple_newsroom.warm_cache(),
+            "refresh": lambda: apple_newsroom.refresh_cache(),
         },
     ]
 
@@ -233,6 +250,23 @@ def apnews_router():
 @app.route(apnews_business_router_path)
 def apnews_business_router():
     return apnews_business.get_rss_xml_response()
+
+
+@app.route(yahoo_news_router_path_prefix + '/<topic>')
+def yahoo_news_router(topic):
+    if topic.lower() not in yahoo_news.VALID_TOPICS:
+        abort(404)
+    return yahoo_news.get_rss_xml_response(parameter={"topic": topic.lower()})
+
+
+@app.route(apple_news_router_path)
+def apple_developer_news_router():
+    return apple_developer_news.get_rss_xml_response()
+
+
+@app.route(apple_newsroom_router_path)
+def apple_newsroom_router():
+    return apple_newsroom.get_rss_xml_response()
 
 
 if should_start_scheduler():

--- a/router/apple_news/apple_news_router.py
+++ b/router/apple_news/apple_news_router.py
@@ -1,0 +1,110 @@
+import logging
+from email.utils import parsedate_to_datetime
+
+import feedparser
+
+from router.router_for_rss_feed import RouterForRssFeed
+from utils.feed_item_object import Metadata, generate_cache_key, convert_router_path_to_cache_prefix
+from utils.get_link_content import get_link_content_with_bs_no_params
+
+
+def _parse_feed_date(date_str):
+    """Convert RSS/Atom date string to datetime, return None on failure."""
+    if not date_str:
+        return None
+    try:
+        return parsedate_to_datetime(date_str)
+    except (ValueError, TypeError):
+        return None
+
+
+class AppleNewsRouter(RouterForRssFeed):
+
+    def _get_articles_list(self, link_filter=None, title_filter=None, parameter=None):
+        """Override to store RSS description in Metadata.flag for no per-article fetch."""
+        metadata_list = []
+        parse_feed = feedparser.parse(self.articles_link)
+        if not parse_feed.entries:
+            logging.warning("Router %s RSS feed has 0 entries from %s", self.router_path, self.articles_link)
+            return metadata_list
+
+        cache_prefix = convert_router_path_to_cache_prefix(self.router_path)
+        for entry in parse_feed.entries:
+            if entry.link and entry.title:
+                metadata = Metadata(
+                    title=entry.title,
+                    link=entry.link,
+                    created_time=_parse_feed_date(entry.get("published") or entry.get("updated")),
+                    cache_key=generate_cache_key(prefix=cache_prefix, name=entry.link),
+                    flag=entry.get("description", ""),
+                )
+                metadata_list.append(metadata)
+
+        logging.info("Router %s built %d articles from RSS feed", self.router_path, len(metadata_list))
+        return metadata_list
+
+    def _get_article_content(self, article_metadata, entry):
+        """Use pre-built RSS description — no network call needed."""
+        entry.description = article_metadata.flag
+        entry.created_time = article_metadata.created_time
+        entry.persist_to_cache(self.router_path)
+
+
+class AppleNewsroomRouter(RouterForRssFeed):
+
+    def _get_articles_list(self, link_filter=None, title_filter=None, parameter=None):
+        """Parse Atom feed, store created_time from 'updated' field."""
+        metadata_list = []
+        parse_feed = feedparser.parse(self.articles_link)
+        if not parse_feed.entries:
+            logging.warning("Router %s RSS feed has 0 entries from %s", self.router_path, self.articles_link)
+            return metadata_list
+
+        cache_prefix = convert_router_path_to_cache_prefix(self.router_path)
+        for entry in parse_feed.entries:
+            if entry.link and entry.title:
+                metadata = Metadata(
+                    title=entry.title.strip(),
+                    link=entry.link,
+                    created_time=_parse_feed_date(entry.get("published") or entry.get("updated")),
+                    cache_key=generate_cache_key(prefix=cache_prefix, name=entry.link),
+                )
+                metadata_list.append(metadata)
+
+        logging.info("Router %s built %d articles from RSS feed", self.router_path, len(metadata_list))
+        return metadata_list
+
+    def _get_article_content(self, article_metadata, entry):
+        """Fetch full article content from the newsroom page."""
+        soup = get_link_content_with_bs_no_params(article_metadata.link)
+        if soup is None:
+            logging.warning("Router %s failed to fetch article %s", self.router_path, article_metadata.link)
+            return
+
+        article = soup.find("article")
+        if not article:
+            logging.warning("Router %s no <article> tag found for %s", self.router_path, article_metadata.link)
+            return
+
+        parts = []
+        for child in article.children:
+            if not hasattr(child, "name") or not child.name:
+                continue
+            classes = child.get("class", [])
+            if "pagebody" in classes:
+                paragraphs = child.find_all("p")
+                if not paragraphs:
+                    paragraphs = child.find_all("div", class_="pagebody-copy")
+                for p in paragraphs:
+                    text = p.get_text(strip=True)
+                    if text:
+                        parts.append(f"<p>{text}</p>")
+            elif child.name == "figure" or "image" in classes or "gallery" in classes:
+                for img in child.find_all("img"):
+                    src = img.get("src", "")
+                    if src:
+                        parts.append(f'<img src="{src}" />')
+
+        entry.description = "\n".join(parts) if parts else ""
+        entry.created_time = article_metadata.created_time
+        entry.persist_to_cache(self.router_path)

--- a/router/apple_news/apple_news_router_constants.py
+++ b/router/apple_news/apple_news_router_constants.py
@@ -1,0 +1,9 @@
+apple_developer_news_title = "Apple Developer News"
+apple_developer_news_description = "Latest News - Apple Developer"
+apple_developer_news_link = "https://developer.apple.com/news/"
+apple_developer_news_rss_link = "https://developer.apple.com/news/rss/news.rss"
+
+apple_newsroom_title = "Apple Newsroom"
+apple_newsroom_description = "Apple Newsroom - Press Releases and Updates"
+apple_newsroom_link = "https://www.apple.com/newsroom/"
+apple_newsroom_rss_link = "https://www.apple.com/ca/newsroom/rss-feed.rss"

--- a/router/base_router.py
+++ b/router/base_router.py
@@ -5,7 +5,7 @@ import pytz
 from flask import make_response
 from datetime import datetime
 
-from utils.cache_store import read_feed_item_from_cache, read_last_build_time, read_metadata_list, write_current_metadata_snapshot, write_last_build_time
+from utils.cache_store import read_feed_item_from_cache, read_last_build_time, read_metadata_list, write_last_build_time, write_metadata_list
 from utils.feed_item_object import Metadata, FeedItem, generate_cache_key, convert_router_path_to_cache_prefix
 from utils.log_context import reset_current_router, set_current_router
 from utils.xml_utilities import generate_feed_object_for_new_router
@@ -53,10 +53,7 @@ class BaseRouter:
         """
         cached_entry = self.__load_article_from_cache(article_metadata.cache_key)
         if cached_entry:
-            logging.info("Router %s using cached article link=%s cache_key=%s", self.router_path, article_metadata.link, article_metadata.cache_key)
-            if self.router_path == '/zaobao/realtime':
-                description = cached_entry.description or ""
-                logging.info("Zaobao cached article loaded for %s (content length=%s)", article_metadata.link, len(description))
+            logging.debug("Router %s cache hit for article link=%s", self.router_path, article_metadata.link)
             return cached_entry
 
         logging.debug("Router %s retrieving article content link=%s", self.router_path, article_metadata.link)
@@ -101,10 +98,10 @@ class BaseRouter:
         feed = self._generate_response(last_build_time=feed_last_build_time,
                                        feed_entries_list=feed_entries_list,
                                        parameter=parameter)
-        logging.info(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} Cache last-build: {feed.lastBuildDate}")
+        logging.debug("Router %s serving feed lastBuildDate=%s", self.router_path, feed.lastBuildDate)
 
         response = make_response(feed.rss())
-        response.headers.set('Content-Type', 'application/rss+xml')
+        response.headers.set('Content-Type', 'application/rss+xml; charset=utf-8')
         return response
 
     def refresh_cache(self, parameter=None, link_filter=None, title_filter=None, force=False):
@@ -137,7 +134,7 @@ class BaseRouter:
                 parameter,
             )
             article_list_key = self._build_article_list_cache_key(cache_key)
-            self.__write_article_list_to_cache(article_list_key, [])
+            self._write_article_list_to_cache(article_list_key, [])
             last_build_time = dt.datetime.now(pytz.timezone('GMT'))
             write_last_build_time(cache_key, last_build_time)
             logging.info(
@@ -168,7 +165,7 @@ class BaseRouter:
 
         article_list_key = self._build_article_list_cache_key(cache_key)
         # Publish the current upstream article list even if some article bodies failed to cache.
-        self.__write_article_list_to_cache(article_list_key, article_metadata_list)
+        self._write_article_list_to_cache(article_list_key, article_metadata_list)
 
         logging.info(
             'Router %s published %d metadata items; article content cached for %d items (previous metadata count=%d) parameter=%s',
@@ -234,10 +231,10 @@ class BaseRouter:
         for article_metadata in article_metadata_list:
             entry = self.__load_article_from_cache(article_metadata.cache_key)
             if entry is None:
-                logging.debug("Router %s cache miss for article key=%s (link=%s)", self.router_path, article_metadata.cache_key, article_metadata.link)
+                logging.warning("Router %s article missing from cache key=%s link=%s", self.router_path, article_metadata.cache_key, article_metadata.link)
                 continue
             elif entry.description is None:
-                logging.debug("Router %s article key=%s (link=%s) dropped: description is None", self.router_path, article_metadata.cache_key, article_metadata.link)
+                logging.warning("Router %s article has None description key=%s link=%s", self.router_path, article_metadata.cache_key, article_metadata.link)
                 continue
             feed_entries_list.append(entry)
         logging.info("Router %s built %d feed entries from cache", self.router_path, len(feed_entries_list))
@@ -246,7 +243,6 @@ class BaseRouter:
         return feed_entries_list
 
     def __generate_cache_key_for_router(self, parameter=None):
-        logging.debug("Router %s generating cache key parameter=%s", self.router_path, parameter)
         if parameter is None:
             cache_key = self.router_path
         else:
@@ -290,11 +286,10 @@ class BaseRouter:
         try:
             return datetime.fromisoformat(value)
         except ValueError:
-            logging.warning(f"Unable to parse created_time from cache: {value}")
+            logging.warning("Unable to parse created_time from cache: %s", value)
             return None
 
-    @staticmethod
-    def __build_metadata_list(metadata_dicts):
+    def __build_metadata_list(self, metadata_dicts):
         if not metadata_dicts:
             return []
 
@@ -303,7 +298,7 @@ class BaseRouter:
             required = ["title", "link", "guid"]
             missing = [f for f in required if f not in metadata_dict]
             if missing:
-                logging.error("Router metadata dict missing required fields %s: %s", missing, metadata_dict)
+                logging.error("Router %s metadata dict missing required fields %s: %s", self.router_path, missing, metadata_dict)
                 continue
             if "json_name" in metadata_dict and "cache_key" not in metadata_dict:
                 metadata_dict["cache_key"] = metadata_dict.pop("json_name")
@@ -311,5 +306,5 @@ class BaseRouter:
         return metadata_objects
 
     @staticmethod
-    def __write_article_list_to_cache(cache_key, article_metadata_list):
-        write_current_metadata_snapshot(cache_key, article_metadata_list)
+    def _write_article_list_to_cache(cache_key, article_metadata_list):
+        write_metadata_list(cache_key, article_metadata_list)

--- a/router/embassy/china_embassy_news.py
+++ b/router/embassy/china_embassy_news.py
@@ -54,18 +54,26 @@ class ChinaEmbassyNewsRouter(BaseRouter):
         if time_div and time_div.get_text():
             entry.created_time = convert_time_with_pattern(time_div.get_text(), "%Y-%m-%d %H:%M")
         else:
-            match = re.search(r"/(20\d{2})(\d{2})(\d{2})_", article_metadata.link)
-            if match:
-                fallback = match.group(1) + match.group(2) + match.group(3)
-                entry.created_time = convert_time_with_pattern(fallback, "%Y%m%d", 0)
-                logging.info("Fallback to URL date %s for %s", fallback, article_metadata.link)
+            # Try YYYY/MM/DD HH:MM pattern (used on china-embassy.org pages)
+            page_text = soup.get_text()
+            slash_match = re.search(r"(\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2})", page_text)
+            if slash_match:
+                entry.created_time = convert_time_with_pattern(slash_match.group(1), "%Y/%m/%d %H:%M")
             else:
-                logging.warning("Failed to find publish time for %s", article_metadata.link)
+                match = re.search(r"/(20\d{2})(\d{2})(\d{2})_", article_metadata.link)
+                if match:
+                    fallback = match.group(1) + match.group(2) + match.group(3)
+                    entry.created_time = convert_time_with_pattern(fallback, "%Y%m%d", 0)
+                    logging.info("Fallback to URL date %s for %s", fallback, article_metadata.link)
+                else:
+                    logging.warning("Failed to find publish time for %s", article_metadata.link)
         for tag in soup.find_all(True):
             tag.attrs = {key: val for key, val in tag.attrs.items() if key != 'style'}
         desc_div = soup.find('div', id='News_Body_Txt_A')
         if desc_div is None:
-            logging.warning("Router %s could not find News_Body_Txt_A div for %s", self.router_path, article_metadata.link)
+            desc_div = soup.find('div', class_='view_default')
+        if desc_div is None:
+            logging.warning("Router %s could not find content div for %s", self.router_path, article_metadata.link)
         entry.description = desc_div
         if not entry.description:
             logging.warning("Router %s description is None for %s", self.router_path, article_metadata.link)

--- a/router/jandan/jandan_router.py
+++ b/router/jandan/jandan_router.py
@@ -35,7 +35,12 @@ class JandanRouter(BaseRouter):
             if h2 is None:
                 link_tag = post.find('a')
                 link = link_tag['href'] if link_tag else '<no link>'
-                logging.warning('JandanRouter post item %d has no h2 tag, skipping link=%s', i, link)
+                post_text = post.get_text(strip=True)[:80]
+                post_class = post.get('class', [])
+                logging.info(
+                    'JandanRouter post item %d has no h2 tag, skipping. link=%s class=%s text=%s',
+                    i, link, post_class, post_text,
+                )
                 continue
             title = h2.text.strip()
             link_tag = h2.find('a')

--- a/router/wsdot/wsdot_news_router.py
+++ b/router/wsdot/wsdot_news_router.py
@@ -1,58 +1,11 @@
 import logging
-from typing import Optional
 
-from router.base_router import BaseRouter
-from router.wsdot.wsdot_news_router_constant import wsdot_blog_blogspot, wsdot_news_prefix
-from utils.feed_item_object import Metadata, convert_router_path_to_cache_prefix, generate_cache_key
+from router.router_for_rss_feed import RouterForRssFeed
 from utils.get_link_content import get_link_content_with_bs_no_params
 from utils.time_converter import convert_wsdot_news_time
 
 
-class WsdotNewsRouter(BaseRouter):
-    def _get_articles_list(self, parameter=None, link_filter=None, title_filter=None):
-        metadata_list = []
-
-        for i in range(0, 3):
-            page_url = f"{self.articles_link}?page={i}"
-            page_soup = get_link_content_with_bs_no_params(page_url)
-            if page_soup is None:
-                logging.warning("Router %s failed to fetch page %d of %s", self.router_path, i, page_url)
-                continue
-
-            views_row_elements = page_soup.find_all("div", class_="views-field views-field-nothing")
-            if not views_row_elements:
-                logging.info("Router %s found 0 views-row elements on page %d of %s", self.router_path, i, page_url)
-
-            for views_row in views_row_elements:
-                h2_tag = views_row.find("h2")
-                if h2_tag is None:
-                    logging.info("Router %s skipped views-row with no h2 tag", self.router_path)
-                    continue
-
-                a_tag = h2_tag.find("a")
-                raw_link: Optional[object] = a_tag.get("href") if a_tag else None
-                title = h2_tag.get_text(strip=True)
-
-                if not isinstance(raw_link, str) or not title:
-                    logging.info("Router %s skipped views-row: link=%s title=%s", self.router_path, raw_link, title[:50])
-                    continue
-
-                link = raw_link
-
-                if link.startswith("/about/news"):
-                    link = wsdot_news_prefix + link
-
-                if link.endswith(".htm"):
-                    link += "l"
-
-                cache_prefix = convert_router_path_to_cache_prefix(self.router_path)
-                metadata = Metadata(title=title, link=link, cache_key=generate_cache_key(prefix=cache_prefix, name=link))
-                metadata_list.append(metadata)
-
-        if not metadata_list:
-            logging.warning("Router %s extracted 0 articles from wsdot after 3 pages", self.router_path)
-
-        return metadata_list
+class WsdotNewsRouter(RouterForRssFeed):
 
     def _get_article_content(self, article_metadata, entry):
         soup = get_link_content_with_bs_no_params(article_metadata.link)
@@ -60,52 +13,19 @@ class WsdotNewsRouter(BaseRouter):
             logging.warning("Router %s failed to fetch article content for %s", self.router_path, article_metadata.link)
             return
 
-        if article_metadata.link.startswith(wsdot_blog_blogspot):
-            self.__extract_wsdot_blog(soup, entry)
-        else:
-            self.__extract_other_news(soup, entry)
-
-    def __extract_wsdot_blog(self, soup, entry):
-        post_content = soup.find("div", class_="post-body entry-content")
-        if post_content is None:
-            logging.warning("Router %s could not find post-body entry-content for %s", self.router_path, entry.link)
-            return
-        entry.description = post_content
-
-        date_header_tag = soup.find("h2", class_="date-header")
-        if date_header_tag is None or date_header_tag.span is None:
-            logging.warning("Router %s could not find date-header span for %s", self.router_path, entry.link)
-            return
-
-        date_header = date_header_tag.span.get_text(strip=True)
-        if not isinstance(date_header, str) or not date_header:
-            logging.warning("Router %s found invalid date-header text for %s", self.router_path, entry.link)
-            return
-
-        entry.created_time = convert_wsdot_news_time(date_header, "%A, %B %d, %Y")
-        entry.persist_to_cache(self.router_path)
-
-    def __extract_other_news(self, soup, entry):
         post_content = soup.find("div", class_="field field--name-body field--type-text-with-summary field--label-hidden field--item")
         if post_content is None:
-            logging.warning("Router %s could not find body field for %s", self.router_path, entry.link)
+            logging.warning("Router %s could not find body field for %s", self.router_path, article_metadata.link)
             return
+
         entry.description = post_content
 
         datetime_div = soup.find("div", class_="field--name-field-date")
-        if datetime_div is None:
-            logging.warning("Router %s could not find field-date for %s", self.router_path, entry.link)
-            return
+        if datetime_div:
+            time_tag = datetime_div.find("time")
+            if time_tag:
+                raw_datetime = time_tag.get("datetime")
+                if isinstance(raw_datetime, str) and raw_datetime:
+                    entry.created_time = convert_wsdot_news_time(raw_datetime, "%Y-%m-%dT%H:%M:%SZ")
 
-        time_tag = datetime_div.find("time")
-        if time_tag is None:
-            logging.warning("Router %s could not find time tag for %s", self.router_path, entry.link)
-            return
-
-        raw_datetime = time_tag.get("datetime")
-        if not isinstance(raw_datetime, str) or not raw_datetime:
-            logging.warning("Router %s could not find time tag with datetime attr for %s", self.router_path, entry.link)
-            return
-
-        entry.created_time = convert_wsdot_news_time(raw_datetime, "%Y-%m-%dT%H:%M:%SZ")
         entry.persist_to_cache(self.router_path)

--- a/router/wsdot/wsdot_news_router_constant.py
+++ b/router/wsdot/wsdot_news_router_constant.py
@@ -1,6 +1,6 @@
 wsdot_news_title = 'WSDOT - News'
 wsdot_news_description = 'Washington State Department of Transportation - News'
 wsdot_news_link = "https://wsdot.wa.gov/about/news"
+wsdot_news_rss_link = "https://wsdot.wa.gov/about/news-rss.xml"
 wsdot_news_prefix = "https://wsdot.wa.gov"
-wsdot_blog_blogspot = "https://wsdotblog.blogspot.com"
 wsdot_news_period = 30 * 60 * 1000  # 10 minutes

--- a/router/yahoo_news/yahoo_news_router.py
+++ b/router/yahoo_news/yahoo_news_router.py
@@ -1,0 +1,252 @@
+import json
+import logging
+import re
+
+import requests
+from bs4 import BeautifulSoup
+
+from router.base_router import BaseRouter
+from utils.feed_item_object import FeedItem, Metadata, generate_cache_key, convert_router_path_to_cache_prefix
+from utils.router_constants import html_parser
+
+
+class YahooNewsRouter(BaseRouter):
+    """Router for Yahoo News Reuters brand page with per-topic filtering."""
+
+    VALID_TOPICS = {"world", "business", "celebrity", "politics", "health", "news", "u.s."}
+
+    _REQUEST_HEADERS = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cached_soup = None
+
+    def _fetch_page(self, url):
+        """Fetch a page with browser-like headers."""
+        logging.debug("Router %s fetching URL=%s", self.router_path, url)
+        try:
+            resp = requests.get(url, headers=self._REQUEST_HEADERS, timeout=15)
+            logging.debug("Router %s fetch URL=%s status=%d length=%d", self.router_path, url, resp.status_code, len(resp.text))
+            return BeautifulSoup(resp.text, html_parser)
+        except Exception:
+            logging.exception("Router %s failed to fetch %s", self.router_path, url)
+            return None
+
+    def _get_articles_list(self, parameter=None, link_filter=None, title_filter=None):
+        topic = (parameter or {}).get("topic")
+        if not topic:
+            logging.warning("Router %s _get_articles_list called without topic parameter", self.router_path)
+            return []
+
+        topic_lower = topic.lower()
+
+        # Use cached soup if available (set by refresh_all_topics), otherwise fetch
+        if self._cached_soup:
+            logging.debug("Router %s using cached soup for topic '%s'", self.router_path, topic_lower)
+            soup = self._cached_soup
+        else:
+            logging.info("Router %s fetching Yahoo Reuters page for topic '%s'", self.router_path, topic_lower)
+            soup = self._fetch_page(self.articles_link)
+            if soup is None:
+                logging.error("Router %s failed to fetch Yahoo Reuters page for topic '%s'", self.router_path, topic_lower)
+                return []
+
+        return self._parse_articles_for_topic(soup, topic_lower)
+
+    def _parse_articles_for_topic(self, soup, topic_lower):
+        """Parse articles from soup for a specific topic."""
+        pub_dates = {}
+        ld_script = soup.find("script", type="application/ld+json")
+        if ld_script:
+            try:
+                ld_data = json.loads(ld_script.string)
+                for part in ld_data.get("hasPart", []):
+                    url = part.get("url", "")
+                    date = part.get("datePublished") or part.get("uploadDate")
+                    if url and date:
+                        pub_dates[url] = date
+                logging.debug("Router %s parsed %d timestamps from JSON-LD", self.router_path, len(pub_dates))
+            except (json.JSONDecodeError, TypeError):
+                logging.warning("Router %s failed to parse JSON-LD for timestamps", self.router_path)
+
+        strm = soup.find("div", id="strm")
+        if not strm:
+            logging.warning("Router %s could not find #strm section on page", self.router_path)
+            return []
+
+        links = strm.find_all("a", attrs={"data-ylk": lambda v: v and "elm:hdln" in v and "subsec:publisher-brand" in v})
+        logging.debug("Router %s found %d headline links in #strm", self.router_path, len(links))
+
+        cache_prefix = convert_router_path_to_cache_prefix(self.router_path)
+        metadata_list = []
+        seen_titles = set()
+        skipped_dedup = 0
+
+        for link in links:
+            ylk = link.get("data-ylk", "")
+            cat_match = re.search(r"cnt_tpc:([^;]+)", ylk)
+            if not cat_match:
+                continue
+            if cat_match.group(1).lower() != topic_lower:
+                continue
+
+            href = link.get("href", "")
+            title = link.get_text(strip=True)
+            if not href or not title:
+                continue
+
+            if title in seen_titles:
+                skipped_dedup += 1
+                logging.debug("Router %s dedup skipped: '%s'", self.router_path, title[:60])
+                continue
+            seen_titles.add(title)
+
+            cache_key = generate_cache_key(cache_prefix, href)
+            metadata = Metadata(
+                title=title,
+                link=href,
+                author="Reuters",
+                created_time=pub_dates.get(href),
+                guid=href,
+                cache_key=cache_key,
+            )
+            metadata_list.append(metadata)
+
+        logging.info(
+            "Router %s topic '%s': %d articles (%d duplicates removed)",
+            self.router_path, topic_lower, len(metadata_list), skipped_dedup,
+        )
+        return metadata_list
+
+    def refresh_all_topics(self):
+        """Fetch the page once and refresh cache for all discovered topics."""
+        logging.info("Router %s refresh_all_topics: fetching page from %s", self.router_path, self.articles_link)
+
+        soup = self._fetch_page(self.articles_link)
+        if soup is None:
+            logging.error("Router %s refresh_all_topics: page fetch failed", self.router_path)
+            return
+
+        # Discover topics on the page
+        strm = soup.find("div", id="strm")
+        if not strm:
+            logging.warning("Router %s refresh_all_topics: no #strm section found", self.router_path)
+            return
+
+        links = strm.find_all("a", attrs={"data-ylk": lambda v: v and "elm:hdln" in v and "subsec:publisher-brand" in v})
+        logging.info("Router %s refresh_all_topics: found %d raw links in #strm", self.router_path, len(links))
+
+        topics_found = set()
+        topic_counts = {}
+        for link in links:
+            ylk = link.get("data-ylk", "")
+            cat_match = re.search(r"cnt_tpc:([^;]+)", ylk)
+            if cat_match:
+                cat = cat_match.group(1).lower()
+                topic_counts[cat] = topic_counts.get(cat, 0) + 1
+                if cat in self.VALID_TOPICS:
+                    topics_found.add(cat)
+
+        logging.info("Router %s refresh_all_topics: category breakdown=%s", self.router_path, topic_counts)
+        logging.info("Router %s refresh_all_topics: valid topics to refresh=%s", self.router_path, topics_found)
+
+        # Cache the soup so _get_articles_list doesn't re-fetch
+        self._cached_soup = soup
+        try:
+            for topic in topics_found:
+                logging.info("Router %s refresh_all_topics: refreshing topic '%s'", self.router_path, topic)
+                self.refresh_cache(parameter={"topic": topic}, force=True)
+        finally:
+            self._cached_soup = None
+            logging.info("Router %s refresh_all_topics: completed for %d topics", self.router_path, len(topics_found))
+
+    def _get_article_content(self, article_metadata: Metadata, entry: FeedItem):
+        logging.info("Router %s fetching article content title='%s' link=%s", self.router_path, article_metadata.title[:50], article_metadata.link)
+
+        try:
+            resp = requests.get(article_metadata.link, headers=self._REQUEST_HEADERS, timeout=15)
+            logging.debug("Router %s article fetch status=%d length=%d link=%s", self.router_path, resp.status_code, len(resp.text), article_metadata.link)
+            soup = BeautifulSoup(resp.text, html_parser)
+        except Exception:
+            logging.exception("Router %s failed to fetch article page for %s", self.router_path, article_metadata.link)
+            entry.description = ""
+            entry.persist_to_cache(self.router_path)
+            return
+
+        # Extract time
+        time_text = ""
+        time_tag = soup.find("time")
+        if time_tag:
+            time_text = time_tag.get_text(strip=True)
+            if time_tag.get("datetime"):
+                entry.created_time = time_tag["datetime"]
+
+        # Extract author
+        author_span = soup.find("span", class_=lambda c: c and "byline-attr-author" in c)
+        if author_span:
+            entry.author = author_span.get_text(strip=True)
+
+        parts = []
+        if time_text:
+            parts.append(f"<p>{time_text}</p>")
+
+        article_tag = soup.find("article")
+        if article_tag:
+            # Extract figures (images) from article
+            figures = article_tag.find_all("figure")
+            for fig in figures:
+                img = fig.find("img")
+                caption = fig.find("figcaption")
+                if img and img.get("src"):
+                    parts.append(f'<img src="{img["src"]}" />')
+                    if caption:
+                        parts.append(f"<p><em>{caption.get_text(strip=True)}</em></p>")
+
+            # Extract paragraphs from article
+            paragraphs = [p for p in article_tag.find_all("p") if len(p.get_text(strip=True)) > 20]
+            for p in paragraphs:
+                parts.append(f"<p>{p.get_text(strip=True)}</p>")
+
+            logging.debug(
+                "Router %s article extracted %d figures, %d paragraphs from <article> tag link=%s",
+                self.router_path, len(figures), len(paragraphs), article_metadata.link,
+            )
+
+        # Fallback for video pages: extract description from JSON-LD
+        if not parts or len(parts) <= 1:
+            logging.debug("Router %s no article body found, trying JSON-LD fallback link=%s", self.router_path, article_metadata.link)
+            best_desc = ""
+            best_thumb = ""
+            for script in soup.find_all("script", type="application/ld+json"):
+                try:
+                    ld = json.loads(script.string)
+                    desc = ld.get("description", "")
+                    if len(desc) > len(best_desc):
+                        best_desc = desc
+                        if ld.get("thumbnailUrl"):
+                            best_thumb = ld["thumbnailUrl"]
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            if best_desc and len(best_desc) > 50:
+                if best_thumb:
+                    parts.insert(1, f'<img src="{best_thumb}" />')
+                desc_soup = BeautifulSoup(best_desc, html_parser)
+                desc_paragraphs = [p for p in desc_soup.find_all("p") if len(p.get_text(strip=True)) > 20]
+                for p in desc_paragraphs:
+                    parts.append(f"<p>{p.get_text(strip=True)}</p>")
+                logging.info(
+                    "Router %s used JSON-LD fallback: %d paragraphs, thumbnail=%s link=%s",
+                    self.router_path, len(desc_paragraphs), bool(best_thumb), article_metadata.link,
+                )
+            else:
+                logging.warning("Router %s no content found for article link=%s", self.router_path, article_metadata.link)
+
+        entry.description = "\n".join(parts) if len(parts) > 1 else ""
+        logging.info(
+            "Router %s article content cached: %d chars, title='%s'",
+            self.router_path, len(entry.description), article_metadata.title[:50],
+        )
+        entry.persist_to_cache(self.router_path)

--- a/router/yahoo_news/yahoo_news_router_constants.py
+++ b/router/yahoo_news/yahoo_news_router_constants.py
@@ -1,0 +1,6 @@
+yahoo_news_router_path_prefix = "/yahoo/reuters"
+yahoo_news_feed_title = "Yahoo News - Reuters"
+yahoo_news_original_link = "https://profiles.yahoo.com/brands/reuters/"
+yahoo_news_articles_link = "https://profiles.yahoo.com/brands/reuters/"
+yahoo_news_description = "Reuters news via Yahoo"
+yahoo_news_period = 5 * 60 * 1000  # 5 minutes

--- a/router_objects.py
+++ b/router_objects.py
@@ -60,7 +60,8 @@ from router.sony_alpha_rumor.sony_alpha_rumor_router_constants import (
     sar_description,
 )
 from router.wsdot.wsdot_news_router import WsdotNewsRouter
-from router.wsdot.wsdot_news_router_constant import wsdot_news_title, wsdot_news_link, wsdot_news_description
+from router.wsdot.wsdot_news_router_constant import wsdot_news_title, wsdot_news_link, wsdot_news_rss_link, \
+    wsdot_news_description
 from router.zaobao.zaobao_realtime_router import ZaobaoRealtimeRouter
 from router.zaobao.zaobao_realtime_router_constants import zaobao_realtime_page_prefix, zaobao_region_general_title
 from utils.config import get_router_period
@@ -80,6 +81,18 @@ from utils.router_constants import (
     apnews_router_path,
     apnews_business_router_path,
 )
+from router.apple_news.apple_news_router import AppleNewsRouter, AppleNewsroomRouter
+from router.apple_news.apple_news_router_constants import (
+    apple_developer_news_title,
+    apple_developer_news_link,
+    apple_developer_news_rss_link,
+    apple_developer_news_description,
+    apple_newsroom_title,
+    apple_newsroom_link,
+    apple_newsroom_rss_link,
+    apple_newsroom_description,
+)
+from utils.router_constants import apple_news_router_path, apple_newsroom_router_path
 
 meta_tech_blog = MetaBlog(
     router_path=meta_engineering_blog_router,
@@ -133,7 +146,7 @@ wsdot_news = WsdotNewsRouter(
     router_path=wsdot_news_router_path,
     feed_title=wsdot_news_title,
     original_link=wsdot_news_link,
-    articles_link=wsdot_news_link,
+    articles_link=wsdot_news_rss_link,
     description=wsdot_news_description,
     language=language_english,
     period=get_router_period("wsdot", 30)
@@ -201,4 +214,43 @@ apnews_business = ApnewsRouter(
     language=language_english,
     period=get_router_period("apnews_business", 15),
     default_topic="business",
+)
+
+from router.yahoo_news.yahoo_news_router import YahooNewsRouter
+from router.yahoo_news.yahoo_news_router_constants import (
+    yahoo_news_feed_title,
+    yahoo_news_original_link,
+    yahoo_news_articles_link,
+    yahoo_news_description,
+)
+from utils.router_constants import yahoo_news_router_path_prefix
+
+yahoo_news = YahooNewsRouter(
+    router_path=yahoo_news_router_path_prefix,
+    feed_title=yahoo_news_feed_title,
+    original_link=yahoo_news_original_link,
+    articles_link=yahoo_news_articles_link,
+    description=yahoo_news_description,
+    language=language_english,
+    period=get_router_period("yahoo_news", 2),
+)
+
+apple_developer_news = AppleNewsRouter(
+    router_path=apple_news_router_path,
+    feed_title=apple_developer_news_title,
+    original_link=apple_developer_news_link,
+    articles_link=apple_developer_news_rss_link,
+    description=apple_developer_news_description,
+    language=language_english,
+    period=get_router_period("apple_developer_news", 60),
+)
+
+apple_newsroom = AppleNewsroomRouter(
+    router_path=apple_newsroom_router_path,
+    feed_title=apple_newsroom_title,
+    original_link=apple_newsroom_link,
+    articles_link=apple_newsroom_rss_link,
+    description=apple_newsroom_description,
+    language=language_english,
+    period=get_router_period("apple_newsroom", 60),
 )

--- a/utils/cache_store.py
+++ b/utils/cache_store.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from utils.config import load_config
 from utils.router_constants import (
     last_build_time_ttl_seconds,
+    feed_item_ttl_seconds,
 )
 config_data = load_config()
 
@@ -145,13 +146,13 @@ def write_last_build_time(cache_key, last_build_time, ttl_seconds=None):
         _log_error("write last build time", exc)
 
 
-def write_feed_item_to_cache(key, payload, ttl_seconds=None):
+def write_feed_item_to_cache(key, payload, ttl_seconds=feed_item_ttl_seconds):
     if not _has_client():
         logging.error("Redis client unavailable; feed item write skipped for key=%s", key)
         return
 
     try:
-        _redis_client.set(key, json.dumps(payload))
+        _redis_client.set(key, json.dumps(payload), ex=ttl_seconds)
     except (redis.RedisError, TypeError) as exc:
         _log_error("write feed item", exc)
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -26,7 +26,7 @@ def load_config() -> dict:
         try:
             with open(config_path) as config_file:
                 config_data = yaml.safe_load(config_file) or {}
-                logging.info(f"Loaded config.yml from {config_path}")
+                logging.debug(f"Loaded config.yml from {config_path}")
         except yaml.YAMLError as exc:
             logging.warning("Failed to parse config.yml at %s: %s", config_path, exc)
     else:

--- a/utils/router_constants.py
+++ b/utils/router_constants.py
@@ -10,6 +10,9 @@ wsdot_news_router_path = '/wsdot/news'
 zaobao_router_path_prefix = "/zaobao/realtime"
 apnews_router_path = "/apnews/top"
 apnews_business_router_path = "/apnews/business"
+yahoo_news_router_path_prefix = "/yahoo/reuters"
+apple_news_router_path = "/apple/developer"
+apple_newsroom_router_path = "/apple/newsroom"
 
 refresh_period_in_minutes = 15
 metadata_list_max_items = 500
@@ -21,6 +24,7 @@ language_english = "en-us"
 
 # Cache TTL defaults (in seconds)
 last_build_time_ttl_seconds = 3600      # 1 hour
+feed_item_ttl_seconds = 604800          # 7 days
 
 # Distributed lock TTL for warm_cache (in seconds)
 warm_lock_ttl_seconds = 300             # 5 minutes

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -27,7 +27,7 @@ def _load_scheduler_interval_minutes():
 
 def run_refresh_job(job):
     try:
-        logging.info(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} Scheduler refresh job: {job['name']}")
+        logging.info("Scheduler refresh job: %s", job['name'])
         job["refresh"]()
     except Exception as exc:
         logging.exception("Scheduler refresh job failed for %s: %s", job["name"], exc)
@@ -89,8 +89,7 @@ def router_refresh_job_scheduler(jobs):
                     _release_warm_lock(job["name"])
             else:
                 logging.info(
-                    "%s Router %s: warm-up skipped; another process is refreshing.",
-                    datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3],
+                    "Router %s: warm-up skipped; another process is refreshing.",
                     job['name'],
                 )
                 lock_held_by_other = True
@@ -100,22 +99,19 @@ def router_refresh_job_scheduler(jobs):
 
         if cache_was_empty is True:
             logging.info(
-                "%s Router %s: cache was empty, warm-up refreshed content. Next scheduled run in %s minutes.",
-                datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3],
+                "Router %s: cache was empty, warm-up refreshed content. Next scheduled run in %s minutes.",
                 job['name'],
                 interval_minutes,
             )
         elif lock_held_by_other:
             logging.info(
-                "%s Router %s: warm-up deferred to another process. Next scheduled run in %s minutes.",
-                datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3],
+                "Router %s: warm-up deferred to another process. Next scheduled run in %s minutes.",
                 job['name'],
                 interval_minutes,
             )
         else:
             logging.info(
-                "%s Router %s: cache was populated, skipping warm-up. Next scheduled run in %s minutes.",
-                datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3],
+                "Router %s: cache was populated, skipping warm-up. Next scheduled run in %s minutes.",
                 job['name'],
                 interval_minutes,
             )


### PR DESCRIPTION
- Add Yahoo Reuters topic feeds and Apple Developer/Newsroom RSS routes.
- Switch WSDOT to its RSS feed while preserving article content extraction.
- Add feed item TTLs, metadata merging, and cleaner scheduler/cache logging.
- Document new Yahoo route configuration in README.